### PR TITLE
Added support for simulate clicks

### DIFF
--- a/content/sandboxscripts.js
+++ b/content/sandboxscripts.js
@@ -34,7 +34,7 @@ Request.prototype = {
 	setRequestHeader: function(header, value) _outer_callFunction(this._token, "setRequestHeader", header, value),
 	getResponseHeader: function(header) _outer_callFunction(this._token, "getResponseHeader", header),
 	open: function(method, url) _outer_callFunction(this._token, "open", method, url),
-	send: function() _outer_callFunction(this._token, "send"),
+	send: function(data) _outer_callFunction(this._token, "send", data),
 };
 
 

--- a/modules/sandboxfactories.jsm
+++ b/modules/sandboxfactories.jsm
@@ -97,5 +97,7 @@ XMLHttpRequest_WRAP.prototype = {
 		}
 		return rv;
 	},
-	send: function() this._xhr.send(null, true)
+	send: function(data) {
+		return this._xhr.send(data, true);
+	}
 };

--- a/plugins/hosturimage.com.json
+++ b/plugins/hosturimage.com.json
@@ -1,0 +1,6 @@
+{
+	"type": "sandbox",
+	"prefix": "hosturimage.com",
+	"match": "^http://(www.)?hosturimage\\.com/img-.+\\.html",
+	"process": "function get(){\n\tvar http = new XMLHttpRequest();\n\tvar url = baseURL;\n\tlog(baseURL);\n\tvar params = \"imgContinue=Continue+to+image+...+\";\n\thttp.open(\"POST\", url, true);\n\n\thttp.setRequestHeader(\"Content-Type\", \"application/x-www-form-urlencoded\");\n\thttp.setRequestHeader(\"Content-Length\", params.length);\n\n\thttp.onload = function() {\n\t\tlog(http.responseText);\n\t\t\tvar patt = new RegExp(\"popitup\\\\('(.+?)'\\\\)\");\n\t\t\tvar res = patt.exec(http.responseText);\n\t\t\tlog(res[1]);\n\t\t\tsetURL(res[1]);\n\t\t\tfinish();\n\t}\n\thttp.onerror = function() {\n\t\tlog(\"Error loading page\");\n\t}\n\thttp.send(params);\n}\nget();"
+}

--- a/plugins/sandboxes/hosturimage.com.process.js
+++ b/plugins/sandboxes/hosturimage.com.process.js
@@ -1,0 +1,24 @@
+function get(){
+	var http = new XMLHttpRequest();
+	var url = baseURL;
+	log(baseURL);
+	var params = "imgContinue=Continue+to+image+...+";
+	http.open("POST", url, true);
+
+	http.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+	http.setRequestHeader("Content-Length", params.length);
+
+	http.onload = function() {
+		log(http.responseText);
+			var patt = new RegExp("popitup\\('(.+?)'\\)");
+			var res = patt.exec(http.responseText);
+			log(res[1]);
+			setURL(res[1]);
+			finish();
+	}
+	http.onerror = function() {
+		log("Error loading page");
+	}
+	http.send(params);
+}
+get();


### PR DESCRIPTION
Added support for simulate clicks("Continue..." buttons) on servers like hosturimage.com. Only one example added but probably support another hosts like:

-    'imagecorn.com'
-    'imagefolks.com'
-    'imagepicsa.com'
-    'img-zone.com'
-    'imgcandy.net'
-    'imgcorn.com'
-    'imgrill.com'
-    'pixup.us'
-    'sxpics.nl'
-    'trikyimg.com'
-    'xximg.net'
-    'xxxscreens.com'
-    'dtpics.biz'
-    'imgmaster.net'      
-    'imageheli.com'
-    'imgtube.net'

(I took this hosts from "justimage" script for greasemonkey)