### PR TITLE
Fix for _r# Tumblr URLs

### DIFF
--- a/plugins/sandboxes/tumblr.com-post.resolve.js
+++ b/plugins/sandboxes/tumblr.com-post.resolve.js
@@ -1,36 +1,32 @@
 (function() {
   "use strict";
   try {
-    var ogI = responseText.match(
-      /<meta property="og:image" content="(.+?)"/i);
-    var type = responseText.match(
-      /<meta property="og:type" content="(?:.+?:)?(.+?)"/i)[1];
-    var obj = responseText.match(
-      /<script.*?type="application\/ld\+json">(.+?)<\/script>/i);
+    var ogI = responseText.match(/<meta property="og:image" content="(.+?)"/i);
+    var type = responseText.match(/<meta property="og:type" content="(?:.+?:)?(.+?)"/i)[1];
+    var obj = responseText.match(/<script.*?type="application\/ld\+json">(.+?)<\/script>/i);
     var url = null;
     var name = null;
-    if (!!obj && !!obj[1]) {
+    if(!!obj && !!obj[1]) {
       obj = JSON.parse(obj[1]);
       var obT = typeof obj.image;
-      if (obT === "string") {
+      if(obT === "string") {
         queueDownload(obj.image);
       }
-      else if (obT === "object") {
-        for (var i of obj.image["@list"]) {
+      else if(obT === "object") {
+        for(var i of obj.image["@list"]) {
           queueDownload(i);
         }
       }
-      if (type === "video") {
-        name = "tumblr_" + ogI[1].match(/\/tumblr_([a-zA-Z0-9]+)_frame/)[1];
-        url = "https://www.tumblr.com/video_file/" +
-              baseURL.match(/\/post\/([0-9]+)/)[1] + "/" + name;
+      if(type === "video") {
+        name = ogI[1].match(/\/(tumblr_[a-zA-Z\d]+)(?:_r\d+)?_frame/)[1];
+        url = "https://www.tumblr.com/video_file/" + baseURL.match(/\/post\/(\d+)/)[1] + "/" + name;
         name = name + ".mp4";
       }
       else {
-          throw new Error("Media not located in object.");
+        throw new Error("Media not located in object.");
       }
     }
-    else if (!!ogI && !!ogI[1]) {
+    else if(!!ogI && !!ogI[1]) {
       url = ogI[1];
     }
     else {
@@ -38,10 +34,6 @@
     }
     setURL(url, name);
   }
-  catch (e) {
-    log(e.message);
-  }
-  finally {
-    finish();
-  }
+  catch (e) { log(e.message); }
+  finally { finish(); }
 })();


### PR DESCRIPTION
I realized that Tumblr revision URLs (_r#) weren't being recognized, so this adjustment should fix that. Also VERY slight fixes.

If anyone can improve on this code, feel free. As when [I originally wrote it](https://github.com/downthemall/anticontainer/issues/106), my goal was to get the downloadable media dynamically. Using the Google Carousel object, it determines image(s) in the page, as well as composing the video URL should one exist in the page. (Tumblr allows images with videos.) It also has a fallback to _og:image_ if for some reason the format changes. These functionalities should be retained.

I'd appreciate cleaner code. I have not been satisfied with how I obtain the video URL (building it from various identifiers in the page instead of finding it as a whole), but videos are presented in iframes and would require making the code more complicated to grab from there. I do know that the video URL will direct to a URL formatted "https://vt.tumblr.com/tumblr_[a-zA-Z\d]+(_r\d+)?.mp4", but since the URL I use is more concise, I assume it should be used to obtain the correct URL. If it is found to be better to use the redirect URL, it can be used.